### PR TITLE
Improve theme discovery

### DIFF
--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -9,6 +9,7 @@ class DummyLLM:
     def __init__(self, values=None):
         self.values = values or {}
         self.called = 0
+        self.token_called = 0
         self.max_workers = 1
         self.model = "gpt-3.5-turbo"
 
@@ -26,6 +27,7 @@ class DummyLLM:
         return outputs
 
     def estimate_tokens(self, texts, model=None):
+        self.token_called += 1
         if isinstance(texts, str):
             texts = [texts]
         return [len((t or "").split()) for t in texts]
@@ -354,3 +356,50 @@ def test_discover_themes_handles_code_fence():
 
     assert "fence" in theme_model.model_fields
     assert ext._last_theme_output == "```json\n{\n  \"fence\": \"ok\"\n}\n```"
+
+
+def test_discover_themes_bool_fields():
+    df = pd.DataFrame({"summary": ["one"]})
+    llm = DummyLLM(values={"example": "desc"})
+    ext = Extractor(llm=llm, reports=df)
+    ext.summarised_reports = df
+    ext.summary_col = "summary"
+
+    theme_model = ext.discover_themes()
+
+    assert theme_model.model_fields["example"].annotation is bool
+
+
+def test_discover_themes_uses_token_cache():
+    df = pd.DataFrame({"summary": ["one", "two"]})
+    llm = DummyLLM(values={})
+    ext = Extractor(llm=llm, reports=df)
+    ext.summarised_reports = df
+    ext.summary_col = "summary"
+    ext.token_cache["summary"] = [1, 2]
+
+    ext.discover_themes()
+
+    assert llm.token_called == 0
+
+
+def test_discover_themes_prompt_limits(monkeypatch):
+    df = pd.DataFrame({"summary": ["one"]})
+    llm = DummyLLM(values={})
+    ext = Extractor(llm=llm, reports=df)
+    ext.summarised_reports = df
+    ext.summary_col = "summary"
+    ext.token_cache["summary"] = [1]
+
+    captured = {}
+
+    def fake_generate(prompts, response_format=None, **kwargs):
+        captured["prompt"] = prompts[0]
+        return [{}]
+
+    monkeypatch.setattr(llm, "generate", fake_generate)
+    ext.discover_themes(max_themes=5, min_themes=2)
+
+    prompt = captured["prompt"].lower()
+    assert "no more than 5" in prompt
+    assert "at least 2" in prompt


### PR DESCRIPTION
## Summary
- add theme discovery constraints and caching
- test new theme discovery cases

## Testing
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848546386e48328b5bc9c7cf99a25b8