### PR TITLE
Switch dataset loading to GitHub release

### DIFF
--- a/.github/workflows/pfd_update.yml
+++ b/.github/workflows/pfd_update.yml
@@ -67,12 +67,16 @@ jobs:
       - name: Update report count in docs
         run: uv run python scripts/update_report_count.py
 
+      - name: Upload dataset to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload dataset-latest all_reports.csv --clobber
+
       - name: Commit & Push Changes
         if: github.ref == 'refs/heads/main'
         uses: EndBug/add-and-commit@v9
         with:
           add: |
-            src/pfd_toolkit/data/all_reports.csv
             docs/index.md
           default_author: github_actions
           message: "🤖 Auto PFD dataset top-up"

--- a/scripts/update_report_count.py
+++ b/scripts/update_report_count.py
@@ -7,9 +7,23 @@ index.md to reflect the current count.
 
 import re
 import pandas as pd
+import requests
 
-csv_path = "src/pfd_toolkit/data/all_reports.csv"
+DATA_URL = (
+    "https://github.com/Sam-Osian/PFD-toolkit/releases/download/"
+    "dataset-latest/all_reports.csv"
+)
+csv_path = "all_reports.csv"
 md_path = "docs/index.md"
+
+# Download dataset
+try:
+    resp = requests.get(DATA_URL, timeout=30)
+    resp.raise_for_status()
+    with open(csv_path, "wb") as f:
+        f.write(resp.content)
+except Exception:
+    pass
 
 # Count number of rows/reports
 df = pd.read_csv(csv_path)

--- a/scripts/update_reports.py
+++ b/scripts/update_reports.py
@@ -5,18 +5,33 @@ Prevention of Future Death (PFD) reports which is bundled with
 the repo (`../pfd_toolkit/data`).
 """
 
-import pandas as pd
-from pfd_toolkit import Scraper, LLM
-from pathlib import Path
 import os
+from pathlib import Path
 
-DATA_PATH = Path("./src/pfd_toolkit/data/all_reports.csv")
+import pandas as pd
+import requests
+from pfd_toolkit import LLM, Scraper
+
+DATA_URL = (
+    "https://github.com/Sam-Osian/PFD-toolkit/releases/download/"
+    "dataset-latest/all_reports.csv"
+)
+DATA_PATH = Path("all_reports.csv")
 
 # Initialise LLM client
 llm_client = LLM(api_key=os.environ["OPENAI_API_KEY"], max_workers=30)
 
 # Initialise scraper
 scraper = Scraper(llm=llm_client, scraping_strategy=[-1,-1,1])
+
+# Retrieve the latest dataset from the GitHub release
+try:
+    resp = requests.get(DATA_URL, timeout=30)
+    resp.raise_for_status()
+    DATA_PATH.write_bytes(resp.content)
+    print(f"DEBUG: Downloaded dataset from {DATA_URL}")
+except Exception:
+    print(f"DEBUG: Failed to download dataset from {DATA_URL}")
 
 # Load existing reports
 if DATA_PATH.exists():


### PR DESCRIPTION
## Summary
- download the dataset from the `dataset-latest` release
- cache downloaded dataset in `load_reports`
- update update scripts to fetch and work with the release asset
- upload refreshed dataset in CI using `gh release upload`

## Testing
- `pip install .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685746da27148328bf386e23dd745a59